### PR TITLE
Typo in 'Atomic deploys' section of homepage

### DIFF
--- a/pages/index.twig
+++ b/pages/index.twig
@@ -85,7 +85,7 @@
 
                     <h2>Atomic deploys</h2>
 
-                    <p>Prepare codebase, warm cache, do over staff, and then deploy them with symlinks!</p>
+                    <p>Prepare codebase, warm cache, do other stuff, and then deploy them with symlinks!</p>
                 </div>
                 <div class="col-md-4">
                     <img src="/assets/icons/parallel.png" class="feature-icon">


### PR DESCRIPTION
change `do over staff` to `do other stuff`