### PR TITLE
Typo in 'Consistency' section of homepage

### DIFF
--- a/pages/index.twig
+++ b/pages/index.twig
@@ -99,7 +99,7 @@
 
                     <h2>Consistency</h2>
 
-                    <p>Deployer keeps consistency between servers, even in parallel mode! If one task falls, next tasks
+                    <p>Deployer keeps consistency between servers, even in parallel mode! If one task fails, subsequent tasks
                         will not be executed on all servers.</p>
                 </div>
             </div>


### PR DESCRIPTION
Change `If one task falls, next tasks...` to `If one task fails, subsequent tasks...`