### PR TITLE
Fix homepage typo

### DIFF
--- a/pages/index.twig
+++ b/pages/index.twig
@@ -49,7 +49,7 @@ chmod +x /usr/local/bin/dep</code></pre>
                     <h2>Deployer Features</h2>
                     <ul>
                         <li><img src="/assets/icons/fast.png"><strong>Fast</strong> Deployer packed full of time-saving features and optimisations, best for performance and development.</li>
-                        <li><img src="/assets/icons/modular.png"><strong>Modular</strong> Create your deploy script from our modular blocks called recipies. You can find common recipes <a href="https://github.com/deployphp/deployer/tree/master/recipe">here</a> and 3rd party recipes <a href="https://github.com/deployphp/recipes">here</a>.</li>
+                        <li><img src="/assets/icons/modular.png"><strong>Modular</strong> Create your deploy script from our modular blocks called recipes. You can find common recipes <a href="https://github.com/deployphp/deployer/tree/master/recipe">here</a> and 3rd party recipes <a href="https://github.com/deployphp/recipes">here</a>.</li>
                         <li><img src="/assets/icons/cleancode.png"><strong>Clean code</strong> Deployer has very clean code and good tested. Repository is watched by many code quality tools, every pull request also checked by QA tools.</li>
                         <li><img src="/assets/icons/rollback.png"><strong>Rollbacks</strong> If something is wrong, a simple rollback to previous release is possible.</li>
                         <li><img src="/assets/icons/atomic.png"><strong>Atomic deploys</strong> Prepare codebase, warm cache, do other stuff, and then deploy them with symlinks!</li>


### PR DESCRIPTION
You had a typo in the word recipes on the homepage.

:+1: 